### PR TITLE
Add message queue overload handling and enable slider throttling on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "futures",
  "iced_core",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "bytes",
  "iced_core",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2313,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#d8c9c8dc2c32df407b88f393b0a58bb45431f42b"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#9dae9afde539c363b4a087543af0ab9ca1b6146b"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -3274,7 +3274,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5724,7 +5724,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -702,6 +702,14 @@ impl iced_winit::runtime::Program for DataViewer {
 
                 // Always use async on Linux for better responsiveness
                 let use_async = true;
+
+                // Use throttle for Linux
+                #[cfg(target_os = "linux")]
+                let use_throttle = true;
+
+                #[cfg(not(target_os = "linux"))]
+                let use_throttle = false;
+
                 
                 if pane_index == -1 {
                     // Master slider - only relevant when is_slider_dual is false
@@ -720,7 +728,7 @@ impl iced_winit::runtime::Program for DataViewer {
                         pane_index, 
                         value as usize, 
                         use_async,
-                        true
+                        use_throttle,
                     );
                 } else {
                     let pane_index_usize = pane_index as usize;
@@ -751,7 +759,7 @@ impl iced_winit::runtime::Program for DataViewer {
                         pane_index, 
                         value as usize, 
                         use_async,
-                        true
+                        use_throttle,
                     );
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -720,7 +720,7 @@ impl iced_winit::runtime::Program for DataViewer {
                         pane_index, 
                         value as usize, 
                         use_async,
-                        false
+                        true
                     );
                 } else {
                     let pane_index_usize = pane_index as usize;
@@ -751,7 +751,7 @@ impl iced_winit::runtime::Program for DataViewer {
                         pane_index, 
                         value as usize, 
                         use_async,
-                        false
+                        true
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 use std::sync::Mutex;
 use std::time::Duration;
 use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use winit::{
     event::WindowEvent,
@@ -82,6 +83,11 @@ static LAST_ASYNC_DELIVERY_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now())
 });
 
+// Add these static variables at module level
+static LAST_QUEUE_LENGTH: AtomicUsize = AtomicUsize::new(0);
+const QUEUE_LOG_THRESHOLD: usize = 20;
+const QUEUE_RESET_THRESHOLD: usize = 50;
+
 fn load_icon() -> Option<winit::window::Icon> {
     let image = image::load_from_memory(ICON).ok()?.into_rgba8();
     let (width, height) = image.dimensions();
@@ -124,6 +130,23 @@ enum Event<T: 'static> {
         make_visible: bool,
         on_open: oneshot::Sender<()>,
     },
+}
+
+fn monitor_message_queue(state: &mut program::State<DataViewer>) {
+    // Check queue length
+    let queue_len = state.queued_messages_len();
+    LAST_QUEUE_LENGTH.store(queue_len, Ordering::SeqCst);
+    
+    // Log if the queue is getting large
+    if queue_len > QUEUE_LOG_THRESHOLD {
+        debug!("Message queue size: {}", queue_len);
+    }
+    
+    // Reset queue if it exceeds our threshold
+    if queue_len > QUEUE_RESET_THRESHOLD {
+        warn!("MESSAGE QUEUE OVERLOAD: {} messages pending - clearing queue", queue_len);
+        state.clear_queued_messages();
+    }
 }
 
 pub fn main() -> Result<(), winit::error::EventLoopError> {
@@ -238,6 +261,9 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                             event: window_event,
                         }) => {
                             let _window_event_start = Instant::now();
+                            
+                            // Monitor the message queue and clear it if it's getting large
+                            monitor_message_queue(state);
                             
                             match window_event {
                                 WindowEvent::Focused(true) => {
@@ -416,7 +442,7 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                                         );
                                         
                                         let total_frame_time = frame_start.elapsed();
-                                        debug!("Total frame time: {:?}", total_frame_time);
+                                        trace!("Total frame time: {:?}", total_frame_time);
                                     }
                                     Err(error) => match error {
                                         wgpu::SurfaceError::OutOfMemory => {
@@ -441,7 +467,7 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                                         
                                         if elapsed.as_secs() >= 1 {
                                             let fps = frame_times.len() as f32 / elapsed.as_secs_f32();
-                                            info!("Current FPS: {:.1}", fps);
+                                            trace!("Current FPS: {:.1}", fps);
                                             
                                             // Store the current FPS value
                                             if let Ok(mut current_fps) = CURRENT_FPS.lock() {
@@ -813,7 +839,7 @@ fn track_async_delivery() {
         let now = Instant::now();
         let elapsed = now.duration_since(*time);
         *time = now;
-        trace!("TIMING: Async delivery time: {:?}", elapsed);
+        trace!("TIMING: Interval between async deliveries: {:?}", elapsed);
     }
     
     // Also check phase alignment

--- a/src/navigation_slider.rs
+++ b/src/navigation_slider.rs
@@ -330,7 +330,7 @@ pub fn update_pos(
     let should_process = if throttle {
         // Platform-specific throttling - use different thresholds for Linux
         #[cfg(target_os = "linux")]
-        const PLATFORM_THROTTLE_MS: u64 = 1; // Much lower for Linux/X11
+        const PLATFORM_THROTTLE_MS: u64 = 10;
         
         #[cfg(not(target_os = "linux"))]
         const PLATFORM_THROTTLE_MS: u64 = _THROTTLE_INTERVAL_MS;


### PR DESCRIPTION
- Enable slider throttling on Linux with a minimum 10ms interval
- Clear the message queue when it exceeds 50 messages to prevent overload
- Addresses #26 