### PR TITLE
Clear primitive storage when closing or re-initializing panes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "futures",
  "iced_core",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "bytes",
  "iced_core",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2293,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.13.5"
-source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#2b36dd7d38cd530e2767ef9229bacaf32d459ab3"
+source = "git+https://github.com/ggand0/iced.git?branch=custom-0.13#70eb0a25ebbf16db4fb02b0fcd50521b0c2f929d"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -2755,9 +2755,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libflate"
@@ -3856,9 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4417,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"

--- a/src/app.rs
+++ b/src/app.rs
@@ -173,8 +173,17 @@ impl DataViewer {
         }
     }
 
+    pub fn clear_primitive_storage(&mut self) {
+        if let Err(e) = self.renderer_request_sender.send(RendererRequest::ClearPrimitiveStorage) {
+            error!("Failed to send ClearPrimitiveStorage request: {:?}", e);
+        }
+    }
+
     pub fn reset_state(&mut self) {
-        // First reset all panes
+        // Reset loading status
+        self.loading_status = loading_status::LoadingStatus::default();
+
+        // Reset all panes
         for pane in &mut self.panes {
             pane.reset_state();
         }
@@ -186,14 +195,17 @@ impl DataViewer {
         self.slider_value = 0;
         self.prev_slider_value = 0;
         self.last_opened_pane = 0;
-        self.loading_status = loading_status::LoadingStatus::default();
+        
         self.skate_right = false;
         self.update_counter = 0;
         self.show_about = false;
         self.last_slider_update = Instant::now();
         self.is_slider_moving = false;
 
-        crate::utils::mem::log_memory("DataViewer::reset_state: After reset_state");   
+        crate::utils::mem::log_memory("DataViewer::reset_state: After reset_state");
+
+        // Clear primitive storage
+        self.clear_primitive_storage();
     }
 
     fn initialize_dir_path(&mut self, path: PathBuf, pane_index: usize) {
@@ -319,6 +331,7 @@ impl DataViewer {
                 // Close the selected panes
                 if modifiers.control() {
                     self.reset_state();
+                    //self.clear_primitive_storage();
                 }
             }
 

--- a/src/cache/img_cache.rs
+++ b/src/cache/img_cache.rs
@@ -416,6 +416,22 @@ impl ImageCache {
 
     #[allow(dead_code)]
     pub fn clear_cache(&mut self) {
+        // Clear all collections
+        self.cached_data.clear();
+        self.cached_image_indices.clear();
+        self.cache_states.clear();
+        self.image_paths.clear();
+        self.num_files = 0;
+        self.current_index = 0;
+        self.current_offset = 0;
+        self.cache_count = 0;
+        self.slider_texture = None;
+
+        // Clear the loading queues
+        self.loading_queue.clear();
+        self.being_loaded_queue.clear();
+
+        // Reinitialize the cached_data vector (load_initial_images() expects this format)
         let mut cached_data = Vec::new();
         for _ in 0..(self.cache_count * 2 + 1) {
             cached_data.push(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ use iced_wgpu::{get_image_rendering_diagnostics, log_image_rendering_stats};
 use iced_wgpu::engine::ImageConfig;
 use std::sync::mpsc::{self, Receiver};
 
+static ICON: &[u8] = include_bytes!("../assets/icon_48.png");
+
 static FRAME_TIMES: Lazy<Mutex<Vec<Instant>>> = Lazy::new(|| {
     Mutex::new(Vec::with_capacity(120))
 });
@@ -75,25 +77,15 @@ static _STATE_UPDATE_STATS: Lazy<Mutex<TimingStats>> = Lazy::new(|| {
 static _WINDOW_EVENT_STATS: Lazy<Mutex<TimingStats>> = Lazy::new(|| {
     Mutex::new(TimingStats::new("Window Event"))
 });
-
-// Add this alongside your other statics
 static CURRENT_MEMORY_USAGE: Lazy<Mutex<u64>> = Lazy::new(|| {
     Mutex::new(0)
 });
-
-// Add this to track last memory update time
 static LAST_MEMORY_UPDATE: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now())
 });
-
-// Add this alongside your other statics
 static LAST_STATS_UPDATE: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now())
 });
-
-static ICON: &[u8] = include_bytes!("../assets/icon_48.png");
-
-// Add these to track the phase relationship
 static LAST_RENDER_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now())
 });
@@ -101,7 +93,6 @@ static LAST_ASYNC_DELIVERY_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now())
 });
 
-// Add these static variables at module level
 static LAST_QUEUE_LENGTH: AtomicUsize = AtomicUsize::new(0);
 const QUEUE_LOG_THRESHOLD: usize = 20;
 const QUEUE_RESET_THRESHOLD: usize = 50;
@@ -172,6 +163,7 @@ fn monitor_message_queue(state: &mut program::State<DataViewer>) {
 // Define a message type for renderer configuration requests
 enum RendererRequest {
     UpdateCompressionStrategy(CompressionStrategy),
+    ClearPrimitiveStorage,
     // Add other renderer configuration requests here if needed
 }
 
@@ -439,6 +431,16 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                                         
                                         debug!("Compression strategy updated successfully in main thread");
                                     }
+                                    RendererRequest::ClearPrimitiveStorage => {
+                                        debug!("Main thread handling primitive storage clear request");
+                                        
+                                        // Get engine lock
+                                        let mut engine_guard = engine.lock().unwrap();
+                                        
+                                        // Access the primitive storage directly
+                                        engine_guard.clear_primitive_storage();
+                                        debug!("Primitive storage cleared successfully");
+                                    },
                                 }
                             }
 

--- a/src/widgets/shader/texture_scene.rs
+++ b/src/widgets/shader/texture_scene.rs
@@ -100,7 +100,7 @@ impl TexturePrimitive {
     }
 }
 
-// Add this struct to hold multiple pipeline instances
+// Struct to hold multiple pipeline instances
 #[derive(Debug, Default)]
 pub struct PipelineRegistry {
     pipelines: std::collections::HashMap<String, TexturePipeline>,


### PR DESCRIPTION
- Clear iced_wgpu's primitive storage in `Engine` via `DataViewer::reset_state()`
- Call DataViewer::reset_state() on file drop events

The app stores `TexturePipeline`s with `Arc<wgpu::Texture>` to primitive storage in `ImageShader::prepare()`. This storage lives inside `iced_wgpu::Engine`. Without clearing it, VRAM usage would keep growing every time the user opens a new directory. This PR makes sure we clear out any old pipelines when reloading or closing panes.