### PR TITLE
Fix split widget layout and hitbox, add support for horizontal split

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -272,6 +272,14 @@ impl DataViewer {
                 self.toggle_slider_type();
             }
 
+            Key::Character("h") | Key::Character("H") => {
+                debug!("H key pressed");
+                // Only toggle split orientation in dual pane mode
+                if self.pane_layout == PaneLayout::DualPane {
+                    self.toggle_split_orientation();
+                }
+            }
+
             Key::Character("1") => {
                 debug!("Key1 pressed");
                 if self.pane_layout == PaneLayout::DualPane && self.is_slider_dual {

--- a/src/app.rs
+++ b/src/app.rs
@@ -524,7 +524,14 @@ impl DataViewer {
                 }
             }
             PaneLayout::DualPane => {
-                let left_pane_filename = if self.panes[0].dir_loaded {
+                // Select labels based on split orientation
+                let (first_label, second_label) = if self.is_horizontal_split {
+                    ("Top", "Bottom")
+                } else {
+                    ("Left", "Right")
+                };
+
+                let first_pane_filename = if self.panes[0].dir_loaded {
                     self.panes[0].img_cache.image_paths[self.panes[0].img_cache.current_index]
                         .file_name()
                         .map(|name| name.to_string_lossy().to_string())
@@ -532,8 +539,8 @@ impl DataViewer {
                 } else {
                     String::from("No File")
                 };
-    
-                let right_pane_filename = if self.panes[1].dir_loaded {
+
+                let second_pane_filename = if self.panes[1].dir_loaded {
                     self.panes[1].img_cache.image_paths[self.panes[1].img_cache.current_index]
                         .file_name()
                         .map(|name| name.to_string_lossy().to_string())
@@ -541,8 +548,8 @@ impl DataViewer {
                 } else {
                     String::from("No File")
                 };
-    
-                format!("Left: {} | Right: {}", left_pane_filename, right_pane_filename)
+
+                format!("{}: {} | {}: {}", first_label, first_pane_filename, second_label, second_pane_filename)
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,8 +85,7 @@ pub enum Message {
     SliderImageWidgetLoaded(Result<(usize, usize, Handle), (usize, usize)>),
     Event(Event),
     ImagesLoaded(Result<(Vec<Option<CachedData>>, Option<LoadOperation>), std::io::ErrorKind>),
-    OnVerResize(u16),
-    OnHorResize(u16),
+    OnSplitResize(u16),
     ResetSplit(u16),
     ToggleSliderType(bool),
     TogglePaneLayout(PaneLayout),
@@ -109,8 +108,7 @@ pub struct DataViewer {
     pub current_image_index: usize,
     pub slider_value: u16,                              // for master slider
     pub prev_slider_value: u16,                         // for master slider
-    pub ver_divider_position: Option<u16>,
-    pub hor_divider_position: Option<u16>,
+    pub divider_position: Option<u16>,
     pub is_slider_dual: bool,
     pub show_footer: bool,
     pub pane_layout: PaneLayout,
@@ -147,8 +145,7 @@ impl DataViewer {
             current_image_index: 0,
             slider_value: 0,
             prev_slider_value: 0,
-            ver_divider_position: None,
-            hor_divider_position: None,
+            divider_position: None,
             is_slider_dual: false,
             show_footer: true,
             pane_layout: PaneLayout::SinglePane,
@@ -733,9 +730,8 @@ impl iced_winit::runtime::Program for DataViewer {
                     }
                 }
             }
-            Message::OnVerResize(position) => { self.ver_divider_position = Some(position); },
-            Message::OnHorResize(position) => { self.hor_divider_position = Some(position); },
-            Message::ResetSplit(_position) => { self.ver_divider_position = None; },
+            Message::OnSplitResize(position) => { self.divider_position = Some(position); },
+            Message::ResetSplit(_position) => { self.divider_position = None; },
             Message::ToggleSliderType(_bool) => { self.toggle_slider_type(); },
             Message::TogglePaneLayout(pane_layout) => { self.toggle_pane_layout(pane_layout); },
             Message::ToggleFooter(_bool) => { self.toggle_footer(); },

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,6 +99,7 @@ pub enum Message {
     SetCacheStrategy(CacheStrategy),
     SetCompressionStrategy(CompressionStrategy),
     ToggleFpsDisplay(bool),
+    ToggleSplitOrientation(bool),
 }
 
 pub struct DataViewer {
@@ -130,6 +131,7 @@ pub struct DataViewer {
     pub show_fps: bool,
     pub compression_strategy: CompressionStrategy,
     pub renderer_request_sender: Sender<RendererRequest>,
+    pub is_horizontal_split: bool,
 }
 
 impl DataViewer {
@@ -170,6 +172,7 @@ impl DataViewer {
             //compression_strategy: CompressionStrategy::Bc1,
             compression_strategy: CompressionStrategy::None,
             renderer_request_sender,
+            is_horizontal_split: false,
         }
     }
 
@@ -620,6 +623,10 @@ impl DataViewer {
             }
         }
     }
+
+    fn toggle_split_orientation(&mut self) {
+        self.is_horizontal_split = !self.is_horizontal_split;
+    }
 }
 
 
@@ -1016,6 +1023,7 @@ impl iced_winit::runtime::Program for DataViewer {
             Message::ToggleFpsDisplay(value) => {
                 self.show_fps = value;
             }
+            Message::ToggleSplitOrientation(_bool) => { self.toggle_split_orientation(); },
         }
 
         if self.skate_right {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -202,6 +202,16 @@ pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
         }))
         (container(
             toggler::Toggler::new(
+                Some("  Horizontal Split".into()),
+                app.is_horizontal_split,
+                Message::ToggleSplitOrientation,
+            ).width(Length::Fill)
+        ).style(|_theme: &WinitTheme| container::Style {
+            text_color: Some(iced_core::Color::from_rgb(0.878, 0.878, 0.878)),
+            ..container::Style::default()
+        }))
+        (container(
+            toggler::Toggler::new(
                 Some("  Toggle FPS Display".into()),
                 app.show_fps,
                 Message::ToggleFpsDisplay,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -209,7 +209,7 @@ pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
         }))
         (container(
             toggler::Toggler::new(
-                Some("  Horizontal Split".into()),
+                Some("  Horizontal Split (H)".into()),
                 app.is_horizontal_split,
                 Message::ToggleSplitOrientation,
             ).width(Length::Fill)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -42,9 +42,16 @@ pub enum PaneLayout {
     DualPane,
 }
 
-const _MENU_FONT_SIZE : u16 = 16;
+const MENU_FONT_SIZE : u16 = 16;
 const MENU_ITEM_FONT_SIZE : u16 = 14;
 const _CARET_PATH : &str = concat!(env!("CARGO_MANIFEST_DIR"), "/assets/svg/caret-right-fill.svg");
+
+// Menu padding constants
+const MENU_PADDING_VERTICAL: u16 = 4; // padding for top and bottom
+const MENU_PADDING_HORIZONTAL: u16 = 8; // padding for left and right
+
+// A constant for the menu bar height that other components can reference
+pub const MENU_BAR_HEIGHT: f32 = (MENU_FONT_SIZE + MENU_PADDING_VERTICAL * 2) as f32; // 16px base height + 8px padding
 
 pub fn button_style(theme: &WinitTheme, status: button::Status, style_type: &str) -> Style {
     match style_type {
@@ -308,37 +315,37 @@ pub fn build_menu(app: &DataViewer) -> MenuBar<Message, WinitTheme, Renderer> {
     menu_bar!(
         (
             container(
-                text("File").size(16).font(Font::with_name("Roboto"))
+                text("File").size(MENU_FONT_SIZE).font(Font::with_name("Roboto"))
             )
             .style(|_theme: &WinitTheme| container::Style {
                 text_color: Some(iced_core::Color::from_rgb(0.878, 0.878, 0.878)),
                 ..container::Style::default()
             })
-            .padding([4, 8]),
+            .padding([MENU_PADDING_VERTICAL, MENU_PADDING_HORIZONTAL]),
             menu_1(app)
         )
 
         (
             container(
-                text("Controls").size(16).font(Font::with_name("Roboto")),//.align_y(alignment::Vertical::Center)
+                text("Controls").size(MENU_FONT_SIZE).font(Font::with_name("Roboto")),//.align_y(alignment::Vertical::Center)
             )
             .style(|_theme: &WinitTheme| container::Style {
                 text_color: Some(iced_core::Color::from_rgb(0.878, 0.878, 0.878)),
                 ..container::Style::default()
             })
-            .padding([4, 8]),
+            .padding([MENU_PADDING_VERTICAL, MENU_PADDING_HORIZONTAL]), // // [top/bottom, left/right
             menu_3(app)
         )
 
         (
             container(
-                text("Help").size(16).font(Font::with_name("Roboto"))
+                text("Help").size(MENU_FONT_SIZE).font(Font::with_name("Roboto"))
             )
             .style(|_theme: &WinitTheme| container::Style {
                 text_color: Some(iced_core::Color::from_rgb(0.878, 0.878, 0.878)),
                 ..container::Style::default()
             })
-            .padding([4, 8]),
+            .padding([MENU_PADDING_VERTICAL, MENU_PADDING_HORIZONTAL]),
             menu_help(app)
         )
     )

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,6 +34,7 @@ use crate::{app::Message, DataViewer};
 use crate::widgets::shader::image_shader::ImageShader;
 use crate::widgets::{split::{Axis, Split}, viewer, dualslider::DualSlider};
 use crate::{CURRENT_FPS, CURRENT_MEMORY_USAGE, pane::IMAGE_RENDER_FPS};
+use crate::menu::MENU_BAR_HEIGHT;
 
 
 fn icon<'a, Message>(codepoint: char) -> Element<'a, Message, WinitTheme, Renderer> {
@@ -329,7 +330,8 @@ pub fn build_ui_dual_pane_slider1(
         Message::OnVerResize,
         Message::ResetSplit,
         Message::FileDropped,
-        Message::PaneSelected
+        Message::PaneSelected,
+        MENU_BAR_HEIGHT,
     )
     .into()
 }
@@ -440,7 +442,8 @@ pub fn build_ui_dual_pane_slider2(
         Message::OnVerResize,
         Message::ResetSplit,
         Message::FileDropped,
-        Message::PaneSelected
+        Message::PaneSelected,
+        MENU_BAR_HEIGHT,
     )
     .into()
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -228,7 +228,7 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
                 // Use individual sliders for each pane (build_ui_dual_pane_slider2)
                 let panes = build_ui_dual_pane_slider2(
                     &app.panes, 
-                    app.ver_divider_position,
+                    app.divider_position,
                     app.show_footer,
                     app.is_slider_moving,
                     app.is_horizontal_split
@@ -252,7 +252,7 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
                 // Build panes using the split component
                 let panes = build_ui_dual_pane_slider1(
                     &app.panes, 
-                    app.ver_divider_position,
+                    app.divider_position,
                     app.is_slider_moving,
                     app.is_horizontal_split
                 );
@@ -312,7 +312,7 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
 
 pub fn build_ui_dual_pane_slider1(
     panes: &[Pane],
-    ver_divider_position: Option<u16>,
+    divider_position: Option<u16>,
     is_slider_moving: bool,
     is_horizontal_split: bool
 ) -> Element<Message, WinitTheme, Renderer> {
@@ -325,9 +325,9 @@ pub fn build_ui_dual_pane_slider1(
         first_img,
         second_img,
         is_selected,
-        ver_divider_position,
+        divider_position,
         if is_horizontal_split { Axis::Horizontal } else { Axis::Vertical },
-        Message::OnVerResize,
+        Message::OnSplitResize,
         Message::ResetSplit,
         Message::FileDropped,
         Message::PaneSelected,
@@ -339,7 +339,7 @@ pub fn build_ui_dual_pane_slider1(
 
 pub fn build_ui_dual_pane_slider2(
     panes: &[Pane],
-    ver_divider_position: Option<u16>,
+    divider_position: Option<u16>,
     show_footer: bool,
     is_slider_moving: bool,
     is_horizontal_split: bool
@@ -437,9 +437,9 @@ pub fn build_ui_dual_pane_slider2(
         first_img,
         second_img,
         is_selected,
-        ver_divider_position,
+        divider_position,
         if is_horizontal_split { Axis::Horizontal } else { Axis::Vertical },
-        Message::OnVerResize,
+        Message::OnSplitResize,
         Message::ResetSplit,
         Message::FileDropped,
         Message::PaneSelected,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -229,7 +229,8 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
                     &app.panes, 
                     app.ver_divider_position,
                     app.show_footer,
-                    app.is_slider_moving
+                    app.is_slider_moving,
+                    app.is_horizontal_split
                 );
                 
                 container(
@@ -251,7 +252,8 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
                 let panes = build_ui_dual_pane_slider1(
                     &app.panes, 
                     app.ver_divider_position,
-                    app.is_slider_moving
+                    app.is_slider_moving,
+                    app.is_horizontal_split
                 );
 
                 let footer_texts = vec![
@@ -310,7 +312,8 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
 pub fn build_ui_dual_pane_slider1(
     panes: &[Pane],
     ver_divider_position: Option<u16>,
-    is_slider_moving: bool
+    is_slider_moving: bool,
+    is_horizontal_split: bool
 ) -> Element<Message, WinitTheme, Renderer> {
     let first_img = panes[0].build_ui_container(is_slider_moving);
     let second_img = panes[1].build_ui_container(is_slider_moving);
@@ -322,7 +325,7 @@ pub fn build_ui_dual_pane_slider1(
         second_img,
         is_selected,
         ver_divider_position,
-        Axis::Vertical,
+        if is_horizontal_split { Axis::Horizontal } else { Axis::Vertical },
         Message::OnVerResize,
         Message::ResetSplit,
         Message::FileDropped,
@@ -336,7 +339,8 @@ pub fn build_ui_dual_pane_slider2(
     panes: &[Pane],
     ver_divider_position: Option<u16>,
     show_footer: bool,
-    is_slider_moving: bool
+    is_slider_moving: bool,
+    is_horizontal_split: bool
 ) -> Element<Message, WinitTheme, Renderer> {
     let footer_texts = vec![
         format!(
@@ -432,7 +436,7 @@ pub fn build_ui_dual_pane_slider2(
         second_img,
         is_selected,
         ver_divider_position,
-        Axis::Vertical,
+        if is_horizontal_split { Axis::Horizontal } else { Axis::Vertical },
         Message::OnVerResize,
         Message::ResetSplit,
         Message::FileDropped,

--- a/src/widgets/split.rs
+++ b/src/widgets/split.rs
@@ -355,6 +355,7 @@ where
                 // Detect double-click event on the divider
                 if divider_layout
                     .bounds()
+                    .expand(10.0)
                     .contains(cursor.position().unwrap_or_default())
                 {
                     split_state.dragging = true;
@@ -521,8 +522,10 @@ where
         let divider_layout = children
             .next()
             .expect("Graphics: Layout should have a divider layout");
+        
+        // Increase the hitbox expansion from 5.0 to 10.0 pixels
         let divider_mouse_interaction = if divider_layout
-            .bounds().expand(5.0)
+            .bounds().expand(10.0)
             .contains(cursor.position().unwrap_or_default())
         {
             match self.axis {
@@ -532,6 +535,7 @@ where
         } else {
             mouse::Interaction::default()
         };
+        
         let second_layout = children
             .next()
             .expect("Graphics: Layout should have a second layout");

--- a/src/widgets/split.rs
+++ b/src/widgets/split.rs
@@ -180,7 +180,7 @@ where
             //divider_init_position: divider_position,
             axis,
             padding: 0.0,
-            spacing: 10.0, // was 5.0
+            spacing: 5.0, // was 5.0
             width: Length::Fill,
             height: Length::Fill,
             min_size_first: 5,
@@ -734,7 +734,7 @@ where
                 },
                 shadow: Default::default(), // No shadow
             },
-            Background::Color(Color::from_rgb(0.8, 0.8, 0.8)), // Using a brighter color for debugging
+            Background::Color(Color::from_rgb(0.2, 0.2, 0.2)),
         );
         
 


### PR DESCRIPTION
- Fix divider centering and even spacing in both vertical and horizontal split modes
- Improve divider hitbox size for easier mouse resizing
- Add a menu item to toggle between horizontal and vertical split modes
- Add `H` keyboard shortcut for toggling split orientation
- Clean up hacky and hard-coded layout blocks