### PR TITLE
Fix image jumping during horizontal split resizing

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -505,7 +505,7 @@ impl Pane {
         debug!("img_cache.cache_count {:?}", self.img_cache.cache_count);
     }
 
-    pub fn build_ui_container(&self, is_slider_moving: bool) -> Container<'_, Message, WinitTheme, Renderer> {
+    pub fn build_ui_container(&self, is_slider_moving: bool, is_horizontal_split: bool) -> Container<'_, Message, WinitTheme, Renderer> {
         if self.dir_loaded {
             if is_slider_moving && self.slider_image.is_some() {
                 // Use regular Image widget during slider movement (much faster)
@@ -523,7 +523,8 @@ impl Pane {
                 let shader_widget = ImageShader::new(Some(scene))
                         .width(Length::Fill)
                         .height(Length::Fill)
-                        .content_fit(iced_winit::core::ContentFit::Contain);
+                        .content_fit(iced_winit::core::ContentFit::Contain)
+                        .horizontal_split(is_horizontal_split);
                 
                 container(center(shader_widget))
                     .width(Length::Fill)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -198,7 +198,8 @@ pub fn build_ui(app: &DataViewer) -> Container<'_, Message, WinitTheme, Renderer
                     let shader = ImageShader::new(Some(scene))
                         .width(Length::Fill)
                         .height(Length::Fill)
-                        .content_fit(iced_winit::core::ContentFit::Contain);
+                        .content_fit(iced_winit::core::ContentFit::Contain)
+                        .horizontal_split(false);
             
                     container(center(shader))
                         .width(Length::Fill)
@@ -347,8 +348,8 @@ pub fn build_ui_dual_pane_slider1(
     is_slider_moving: bool,
     is_horizontal_split: bool
 ) -> Element<Message, WinitTheme, Renderer> {
-    let first_img = panes[0].build_ui_container(is_slider_moving);
-    let second_img = panes[1].build_ui_container(is_slider_moving);
+    let first_img = panes[0].build_ui_container(is_slider_moving, is_horizontal_split);
+    let second_img = panes[1].build_ui_container(is_slider_moving, is_horizontal_split);
     
     let is_selected: Vec<bool> = panes.iter().map(|pane| pane.is_selected).collect();
     Split::new(
@@ -392,7 +393,7 @@ pub fn build_ui_dual_pane_slider2(
         container(
             if show_footer { 
                 column![
-                    panes[0].build_ui_container(is_slider_moving),
+                    panes[0].build_ui_container(is_slider_moving, is_horizontal_split),
                     DualSlider::new(
                         0..=(panes[0].img_cache.num_files - 1) as u16,
                         panes[0].slider_value,
@@ -405,7 +406,7 @@ pub fn build_ui_dual_pane_slider2(
                 ]
             } else { 
                 column![
-                    panes[0].build_ui_container(is_slider_moving),
+                    panes[0].build_ui_container(is_slider_moving, is_horizontal_split),
                     DualSlider::new(
                         0..=(panes[0].img_cache.num_files - 1) as u16,
                         panes[0].slider_value,
@@ -429,7 +430,7 @@ pub fn build_ui_dual_pane_slider2(
         container(
             if show_footer { 
                 column![
-                    panes[1].build_ui_container(is_slider_moving),
+                    panes[1].build_ui_container(is_slider_moving, is_horizontal_split),
                     DualSlider::new(
                         0..=(panes[1].img_cache.num_files - 1) as u16,
                         panes[1].slider_value,
@@ -442,7 +443,7 @@ pub fn build_ui_dual_pane_slider2(
                 ]
             } else { 
                 column![
-                    panes[1].build_ui_container(is_slider_moving),
+                    panes[1].build_ui_container(is_slider_moving, is_horizontal_split),
                     DualSlider::new(
                         0..=(panes[1].img_cache.num_files - 1) as u16,
                         panes[1].slider_value,

--- a/src/widgets/shader/image_shader.rs
+++ b/src/widgets/shader/image_shader.rs
@@ -15,6 +15,7 @@ use crate::widgets::shader::texture_pipeline::TexturePipeline;
 use crate::Scene;
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use crate::widgets::split::DIVIDER_HITBOX_EXPANSION;
 
 
 /// A specialized shader widget for displaying images with proper aspect ratio.
@@ -518,19 +519,19 @@ where
 
         // Adjust the effective mouse bounds to account for the split divider's expanded hitbox
         let effective_bounds = if self.is_horizontal_split {
-            // For horizontal split, shrink top and bottom by 10px
+            // For horizontal split, shrink top and bottom by the divider hitbox expansion amount
             Rectangle {
                 x: bounds.x,
-                y: bounds.y + 10.0, 
+                y: bounds.y + DIVIDER_HITBOX_EXPANSION, 
                 width: bounds.width,
-                height: bounds.height - 20.0,
+                height: bounds.height - (2.0 * DIVIDER_HITBOX_EXPANSION),
             }
         } else {
-            // For vertical split, shrink left and right by 10px
+            // For vertical split, shrink left and right by the divider hitbox expansion amount
             Rectangle {
-                x: bounds.x + 10.0,
+                x: bounds.x + DIVIDER_HITBOX_EXPANSION,
                 y: bounds.y,
-                width: bounds.width - 20.0, 
+                width: bounds.width - (2.0 * DIVIDER_HITBOX_EXPANSION), 
                 height: bounds.height,
             }
         };

--- a/src/widgets/split.rs
+++ b/src/widgets/split.rs
@@ -68,6 +68,9 @@ use std::time::{Duration, Instant};
 #[allow(unused_imports)]
 use log::{Level, debug, info, warn, error};
 
+/// Amount to expand the divider hitbox by on each side in pixels
+pub const DIVIDER_HITBOX_EXPANSION: f32 = 10.0;
+
 /// A split can divide the available space by half to display two different elements.
 /// It can split horizontally or vertically.
 ///
@@ -533,9 +536,9 @@ where
             .next()
             .expect("Graphics: Layout should have a divider layout");
         
-        // Increase the hitbox expansion from 5.0 to 10.0 pixels
+        // Use the constant instead of hardcoded value
         let divider_mouse_interaction = if divider_layout
-            .bounds().expand(10.0)
+            .bounds().expand(DIVIDER_HITBOX_EXPANSION)
             .contains(cursor.position().unwrap_or_default())
         {
             match self.axis {
@@ -695,7 +698,7 @@ where
         );
 
         let bounds_divider = divider_layout.bounds();
-        let is_mouse_over_divider = cursor.is_over(bounds_divider.expand(5.0));
+        let is_mouse_over_divider = cursor.is_over(bounds_divider.expand(DIVIDER_HITBOX_EXPANSION / 2.0));
 
         let status_divider = if is_mouse_over_divider {
             let state = tree.state.downcast_ref::<State>();


### PR DESCRIPTION
Fixes the issue where the image panning logic was called during the divider movement due to the expanded hitbox. Added effective bounds calculation to shrink the hitbox by 10px and prevent unintended offset updates during pane resizing.