### PR TITLE
Refine keyboard shortcuts and add first/last image navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ In dual-pane mode (**Ctrl + 2**), the slider syncs images in both panes by defau
 You can switch to per-pane sliders by selecting the "Controls -> Controls -> Toggle Slider" menu item or pressing the **Space** bar.
 
 ## Shortcuts
-- **Arrow keys (Left / Right) or A / D**: Show previous / next image
-- **Shift + arrow keys (Left / Right) or Shift + A / D**: Render previous / next images continuously ("skate" mode)
-- **Tab**: Show / hide the slider and footer UI
-- **Space**: Toggle between single slider and dual slider
-- **`1` and `2` keys**: Select Pane 1 or Pane 2
-- **Ctrl + 1 or 2**: Toggle between single pane and dual pane mode
-- **Ctrl + W**: Close all panes
-- **Ctrl + Q**: Exit
+| Action                             | macOS Shortcut      | Windows/Linux Shortcut |
+|------------------------------------|----------------------|-------------------------|
+| Show previous / next image         | Left / Right or A / D | Left / Right or A / D  |
+| Continuous scroll ("skate" mode)   | Shift + Left / Right or Shift + A / D | Shift + Left / Right or Shift + A / D |
+| Jump to first / last image         | Cmd + Left / Right   | Ctrl + Left / Right    |
+| Toggle UI (slider + footer)        | Tab                  | Tab                    |
+| Toggle single / dual slider        | Space                | Space                  |
+| Select Pane 1 / 2 (Dual slider)    | 1 / 2                | 1 / 2                  |
+| Open folder in Pane 1 / 2          | Alt + 1 / 2          | Alt + 1 / 2            |
+| Open file in Pane 1 / 2            | Shift + Alt + 1 / 2  | Shift + Alt + 1 / 2    |
+| Toggle single / dual pane mode     | Cmd + 1 / 2          | Ctrl + 1 / 2           |
+| Close all panes                    | Cmd + W              | Ctrl + W               |
+| Exit                               | Cmd + Q              | Ctrl + Q               |
+
 
 ## Resources
 - [Website](https://viewskater.com/)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You can switch to per-pane sliders by selecting the "Controls -> Controls -> Tog
 | Select Pane 1 / 2 (Dual slider)    | 1 / 2                | 1 / 2                  |
 | Open folder in Pane 1 / 2          | Alt + 1 / 2          | Alt + 1 / 2            |
 | Open file in Pane 1 / 2            | Shift + Alt + 1 / 2  | Shift + Alt + 1 / 2    |
+| Open file (Single pane)            | Cmd + O              | Ctrl + O               |
+| Open folder (Single pane)          | Cmd + Shift + O      | Ctrl + Shift + O       |
 | Toggle single / dual pane mode     | Cmd + 1 / 2          | Ctrl + 1 / 2           |
 | Close all panes                    | Cmd + W              | Ctrl + W               |
 | Exit                               | Cmd + Q              | Ctrl + Q               |

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,6 +261,16 @@ impl DataViewer {
 
     fn handle_key_pressed_event(&mut self, key: keyboard::Key, modifiers: keyboard::Modifiers) -> Vec<Task<Message>> {
         let mut tasks = Vec::new();
+        
+        // Helper function to check for the platform-appropriate modifier key
+        let is_platform_modifier = |modifiers: &keyboard::Modifiers| -> bool {
+            #[cfg(target_os = "macos")]
+            return modifiers.logo(); // Use Command key on macOS
+            
+            #[cfg(not(target_os = "macos"))]
+            return modifiers.control(); // Use Control key on other platforms
+        };
+        
         match key.as_ref() {
             Key::Named(Named::Tab) => {
                 debug!("Tab pressed");
@@ -341,14 +351,16 @@ impl DataViewer {
             Key::Character("c") |
             Key::Character("w") => {
                 // Close the selected panes
-                if modifiers.control() {
+                if is_platform_modifier(&modifiers) {
                     self.reset_state(-1);
                 }
             }
 
             Key::Character("q") => {
                 // Terminate the app
-                std::process::exit(0);
+                if is_platform_modifier(&modifiers) {
+                    std::process::exit(0);
+                }
             }
 
             Key::Named(Named::ArrowLeft) | Key::Character("a") => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -296,16 +296,16 @@ impl DataViewer {
                     self.panes[0].is_selected = !self.panes[0].is_selected;
                 }
 
-                // If alt+platform_modifier is pressed, load a file into pane0
-                if modifiers.alt() && is_platform_modifier(&modifiers) {
-                    debug!("Key1 Shift pressed");
+                // If shift+alt is pressed, load a file into pane0
+                if modifiers.shift() && modifiers.alt() {
+                    debug!("Key1 Shift+Alt pressed");
                     tasks.push(Task::perform(file_io::pick_file(), move |result| {
                         Message::FolderOpened(result, 0)
                     }));
                 }
 
                 // If alt is pressed, load a folder into pane0
-                if modifiers.alt() {
+                else if modifiers.alt() {
                     debug!("Key1 Alt pressed");
                     tasks.push(Task::perform(file_io::pick_folder(), move |result| {
                         Message::FolderOpened(result, 0)
@@ -313,7 +313,7 @@ impl DataViewer {
                 }
 
                 // If platform_modifier is pressed, switch to single pane layout
-                if is_platform_modifier(&modifiers) {
+                else if is_platform_modifier(&modifiers) {
                     self.toggle_pane_layout(PaneLayout::SinglePane);
                 }
             }
@@ -324,16 +324,16 @@ impl DataViewer {
                         self.panes[1].is_selected = !self.panes[1].is_selected;
                     }
                 
-                    // If alt+platform_modifier is pressed, load a file into pane1
-                    if modifiers.alt() && is_platform_modifier(&modifiers) {
-                        debug!("Key2 Shift pressed");
+                    // If shift+alt is pressed, load a file into pane1
+                    if modifiers.shift() && modifiers.alt() {
+                        debug!("Key2 Shift+Alt pressed");
                         tasks.push(Task::perform(file_io::pick_file(), move |result| {
                             Message::FolderOpened(result, 1)
                         }));
                     }
 
                     // If alt is pressed, load a folder into pane1
-                    if modifiers.alt() {
+                    else if modifiers.alt() {
                         debug!("Key2 Alt pressed");
                         tasks.push(Task::perform(file_io::pick_folder(), move |result| {
                             Message::FolderOpened(result, 1)
@@ -342,7 +342,7 @@ impl DataViewer {
                 }
 
                 // If platform_modifier is pressed, switch to dual pane layout
-                if is_platform_modifier(&modifiers) {
+                else if is_platform_modifier(&modifiers) {
                     debug!("Key2 Ctrl pressed");
                     self.toggle_pane_layout(PaneLayout::DualPane);
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -363,6 +363,32 @@ impl DataViewer {
                 }
             }
 
+            Key::Character("o") => {
+                // If platform_modifier is pressed, open a file or folder
+                if is_platform_modifier(&modifiers) {
+                    let pane_index = if self.pane_layout == PaneLayout::SinglePane {
+                        0 // Use first pane in single-pane mode
+                    } else {
+                        self.last_opened_pane as usize // Use last opened pane in dual-pane mode
+                    };
+                    debug!("o key pressed pane_index: {}", pane_index);
+
+                    // If shift is pressed or we have uppercase O, open folder
+                    if modifiers.shift() {
+                        debug!("Opening folder with platform_modifier+shift+o");
+                        tasks.push(Task::perform(file_io::pick_folder(), move |result| {
+                            Message::FolderOpened(result, pane_index)
+                        }));
+                    } else {
+                        // Otherwise open file
+                        debug!("Opening file with platform_modifier+o");
+                        tasks.push(Task::perform(file_io::pick_file(), move |result| {
+                            Message::FolderOpened(result, pane_index)
+                        }));
+                    }
+                }
+            }
+
             Key::Named(Named::ArrowLeft) | Key::Character("a") => {
                 // Check for first image navigation with platform modifier or Fn key
                 if is_platform_modifier(&modifiers) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -296,8 +296,8 @@ impl DataViewer {
                     self.panes[0].is_selected = !self.panes[0].is_selected;
                 }
 
-                // If alt+ctrl is pressed, load a file into pane0
-                if modifiers.alt() && modifiers.control() {
+                // If alt+platform_modifier is pressed, load a file into pane0
+                if modifiers.alt() && is_platform_modifier(&modifiers) {
                     debug!("Key1 Shift pressed");
                     tasks.push(Task::perform(file_io::pick_file(), move |result| {
                         Message::FolderOpened(result, 0)
@@ -312,8 +312,8 @@ impl DataViewer {
                     }));
                 }
 
-                // If ctrl is pressed, switch to single pane layout
-                if modifiers.control() {
+                // If platform_modifier is pressed, switch to single pane layout
+                if is_platform_modifier(&modifiers) {
                     self.toggle_pane_layout(PaneLayout::SinglePane);
                 }
             }
@@ -324,8 +324,8 @@ impl DataViewer {
                         self.panes[1].is_selected = !self.panes[1].is_selected;
                     }
                 
-                    // If alt+ctrl is pressed, load a file into pane1
-                    if modifiers.alt() && modifiers.control() {
+                    // If alt+platform_modifier is pressed, load a file into pane1
+                    if modifiers.alt() && is_platform_modifier(&modifiers) {
                         debug!("Key2 Shift pressed");
                         tasks.push(Task::perform(file_io::pick_file(), move |result| {
                             Message::FolderOpened(result, 1)
@@ -341,8 +341,8 @@ impl DataViewer {
                     }
                 }
 
-                // If ctrl is pressed, switch to dual pane layout
-                if modifiers.control() {
+                // If platform_modifier is pressed, switch to dual pane layout
+                if is_platform_modifier(&modifiers) {
                     debug!("Key2 Ctrl pressed");
                     self.toggle_pane_layout(PaneLayout::DualPane);
                 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -296,7 +296,7 @@ pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> 
     // Use platform-specific modifier text for menu items
     #[cfg(target_os = "macos")]
     let (open_folder_text, open_file_text, close_text, quit_text) = 
-        ("Open Folder (⇧⌘O)", "Open File (⌘O)", "Close (⌘W)", "Quit (⌘Q)");
+        ("Open Folder (Cmd+Shift+O)", "Open File (Cmd+O)", "Close (Cmd+W)", "Quit (Cmd+Q)");
     
     #[cfg(not(target_os = "macos"))]
     let (open_folder_text, open_file_text, close_text, quit_text) = 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -171,8 +171,8 @@ pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
     // Use platform-specific modifier text for menu items
     #[cfg(target_os = "macos")]
     let (single_pane_text, dual_pane_text) = (
-        if app.pane_layout == PaneLayout::SinglePane { "[x] Single Pane (⌘1)" } else { "[  ] Single Pane (⌘1)" },
-        if app.pane_layout == PaneLayout::DualPane { "[x] Dual Pane (⌘2)" } else { "[  ] Dual Pane (⌘2)" }
+        if app.pane_layout == PaneLayout::SinglePane { "[x] Single Pane (Cmd+1)" } else { "[  ] Single Pane (Cmd+1)" },
+        if app.pane_layout == PaneLayout::DualPane { "[x] Dual Pane (Cmd+2)" } else { "[  ] Dual Pane (Cmd+2)" }
     );
     
     #[cfg(not(target_os = "macos"))]
@@ -327,7 +327,7 @@ pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> 
     
     // Use platform-specific modifier text for menu items
     #[cfg(target_os = "macos")]
-    let (close_text, quit_text) = ("Close (⌘W)", "Quit (⌘Q)");
+    let (close_text, quit_text) = ("Close (Cmd+W)", "Quit (Cmd+Q)");
     
     #[cfg(not(target_os = "macos"))]
     let (close_text, quit_text) = ("Close (Ctrl+W)", "Quit (Ctrl+Q)");

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -293,6 +293,15 @@ pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
 pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
     let menu_tpl_2 = |items| Menu::new(items).max_width(200.0).offset(5.0);
     
+    // Use platform-specific modifier text for menu items
+    #[cfg(target_os = "macos")]
+    let (open_folder_text, open_file_text, close_text, quit_text) = 
+        ("Open Folder (⇧⌘O)", "Open File (⌘O)", "Close (⌘W)", "Quit (⌘Q)");
+    
+    #[cfg(not(target_os = "macos"))]
+    let (open_folder_text, open_file_text, close_text, quit_text) = 
+        ("Open Folder (Ctrl+Shift+O)", "Open File (Ctrl+O)", "Close (Ctrl+W)", "Quit (Ctrl+Q)");
+    
     // Create submenu for "Open Folder"
     let open_folder_submenu = Menu::new(menu_items!(
         (labeled_button(
@@ -325,17 +334,10 @@ pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> 
     .max_width(180.0)
     .spacing(0.0);
     
-    // Use platform-specific modifier text for menu items
-    #[cfg(target_os = "macos")]
-    let (close_text, quit_text) = ("Close (Cmd+W)", "Quit (Cmd+Q)");
-    
-    #[cfg(not(target_os = "macos"))]
-    let (close_text, quit_text) = ("Close (Ctrl+W)", "Quit (Ctrl+Q)");
-    
     menu_tpl_2(
         menu_items!(
-            (submenu_button("Open Folder", MENU_ITEM_FONT_SIZE), open_folder_submenu)
-            (submenu_button("Open File", MENU_ITEM_FONT_SIZE), open_file_submenu)
+            (submenu_button(open_folder_text, MENU_ITEM_FONT_SIZE), open_folder_submenu)
+            (submenu_button(open_file_text, MENU_ITEM_FONT_SIZE), open_file_submenu)
             (labeled_button(close_text, MENU_ITEM_FONT_SIZE, Message::Close))
             (labeled_button(quit_text, MENU_ITEM_FONT_SIZE, Message::Quit))
         )

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -291,6 +291,10 @@ pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
 }
 
 pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
+    #[cfg(target_os = "macos")]
+    let menu_tpl_2 = |items| Menu::new(items).max_width(210.0).offset(5.0);
+    
+    #[cfg(not(target_os = "macos"))]
     let menu_tpl_2 = |items| Menu::new(items).max_width(200.0).offset(5.0);
     
     // Use platform-specific modifier text for menu items

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -312,12 +312,12 @@ pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> 
     // Create submenu for "Open File"
     let open_file_submenu = Menu::new(menu_items!(
         (labeled_button(
-            "Pane 1 (Alt+Ctrl+1)",
+            "Pane 1 (Shift+Alt+1)",
             MENU_ITEM_FONT_SIZE,
             Message::OpenFile(0)
         ))
         (labeled_button(
-            "Pane 2 (Alt+Ctrl+2)",
+            "Pane 2 (Shift+Alt+2)",
             MENU_ITEM_FONT_SIZE,
             Message::OpenFile(1)
         ))

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -168,8 +168,18 @@ fn submenu_button(label: &str, text_size: u16) -> button::Button<Message, WinitT
 }
 
 pub fn menu_3<'a>(app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> {
-    let single_pane_text = if app.pane_layout == PaneLayout::SinglePane { "[x] Single Pane (Ctrl+1)" } else { "[  ] Single Pane (Ctrl+1)" };
-    let dual_pane_text = if app.pane_layout == PaneLayout::DualPane { "[x] Dual Pane (Ctrl+2)" } else { "[  ] Dual Pane (Ctrl+2)" };
+    // Use platform-specific modifier text for menu items
+    #[cfg(target_os = "macos")]
+    let (single_pane_text, dual_pane_text) = (
+        if app.pane_layout == PaneLayout::SinglePane { "[x] Single Pane (⌘1)" } else { "[  ] Single Pane (⌘1)" },
+        if app.pane_layout == PaneLayout::DualPane { "[x] Dual Pane (⌘2)" } else { "[  ] Dual Pane (⌘2)" }
+    );
+    
+    #[cfg(not(target_os = "macos"))]
+    let (single_pane_text, dual_pane_text) = (
+        if app.pane_layout == PaneLayout::SinglePane { "[x] Single Pane (Ctrl+1)" } else { "[  ] Single Pane (Ctrl+1)" },
+        if app.pane_layout == PaneLayout::DualPane { "[x] Dual Pane (Ctrl+2)" } else { "[  ] Dual Pane (Ctrl+2)" }
+    );
 
     let pane_layout_submenu = Menu::new(menu_items!(
         (labeled_button(
@@ -315,12 +325,19 @@ pub fn menu_1<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Renderer> 
     .max_width(180.0)
     .spacing(0.0);
     
+    // Use platform-specific modifier text for menu items
+    #[cfg(target_os = "macos")]
+    let (close_text, quit_text) = ("Close (⌘W)", "Quit (⌘Q)");
+    
+    #[cfg(not(target_os = "macos"))]
+    let (close_text, quit_text) = ("Close (Ctrl+W)", "Quit (Ctrl+Q)");
+    
     menu_tpl_2(
         menu_items!(
             (submenu_button("Open Folder", MENU_ITEM_FONT_SIZE), open_folder_submenu)
             (submenu_button("Open File", MENU_ITEM_FONT_SIZE), open_file_submenu)
-            (labeled_button("Close (Ctrl+W)", MENU_ITEM_FONT_SIZE, Message::Close))
-            (labeled_button("Quit (Ctrl+Q)", MENU_ITEM_FONT_SIZE, Message::Quit))
+            (labeled_button(close_text, MENU_ITEM_FONT_SIZE, Message::Close))
+            (labeled_button(quit_text, MENU_ITEM_FONT_SIZE, Message::Quit))
         )
     )
 }


### PR DESCRIPTION
Implements the following improvements:
- Fix the issue where the shortcut for quitting the app was `q` instead of `modifier` + `q`
- Use platform-specific modifiers for shortcuts (Cmd + keys on macOS, Ctrl + keys on Windows / Linux)
- Add shortcuts to navigate to the first and last image in the folder (modifier + Arrow left / right or modifier + A/D)
- Revise file-opening shortcuts (Shift + Alt + 1 / 2) for better ergonomics
- Add dedicated single-pane shortcuts: modifier + O to open a file, modifier + Shift + O to open a folder
- Update the shortcuts section in the README to a markdown table

Closes #38  
Closes #39