### PR TITLE
Implement build metadata embedding and Info.plist integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ cargo-bundle = "0.6.0"
 
 [build-dependencies]
 winres = "0.1.12"
+chrono = { version = "0.4", features = ["clock"] }
 
 [package.metadata.winres]
 OriginalFilename = "view_skater.exe"

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,17 @@ use {
     std::{
         env,
         io,
+        process::Command,
+        fs,
     },
     winres::WindowsResource,
 };
 
 fn main() -> io::Result<()> {
+    // Capture build information
+    capture_build_info();
+    
+    // Windows resource setup
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             // This path can be absolute, or relative to your crate root.
@@ -18,4 +24,105 @@ fn main() -> io::Result<()> {
             .compile()?;
     }
     Ok(())
+}
+
+fn capture_build_info() {
+    // Get version from Cargo.toml
+    println!("cargo:rustc-env=CARGO_PKG_VERSION={}", env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string()));
+    
+    // Generate build timestamp
+    let build_timestamp = chrono::Utc::now().format("%Y%m%d.%H%M%S").to_string();
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", build_timestamp);
+    
+    // Get git commit hash
+    let git_hash = get_git_hash().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    
+    // Get git commit hash (short version)
+    let git_hash_short = if git_hash.len() >= 7 {
+        git_hash[0..7].to_string()
+    } else {
+        git_hash.clone()
+    };
+    println!("cargo:rustc-env=GIT_HASH_SHORT={}", git_hash_short);
+    
+    // Target platform info
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=TARGET_PLATFORM={}-{}", target_arch, target_os);
+    
+    // Build profile
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=BUILD_PROFILE={}", profile);
+    
+    // Create a combined build string
+    let build_string = format!("{}.{}", env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string()), build_timestamp);
+    println!("cargo:rustc-env=BUILD_STRING={}", build_string);
+    
+    // Always update Info.plist with the build timestamp if it exists
+    // This ensures consistent versioning across all builds
+    update_info_plist(&build_timestamp);
+    println!("cargo:rustc-env=BUNDLE_VERSION={}", build_timestamp);
+    
+    // Tell cargo to rerun this if git changes or Info.plist changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads/");
+    println!("cargo:rerun-if-changed=resources/macos/Info.plist");
+}
+
+fn get_git_hash() -> Option<String> {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    
+    if output.status.success() {
+        let hash = String::from_utf8(output.stdout).ok()?;
+        Some(hash.trim().to_string())
+    } else {
+        None
+    }
+}
+
+fn update_info_plist(build_timestamp: &str) {
+    let plist_path = "resources/macos/Info.plist";
+    
+    // Check if Info.plist exists
+    if !std::path::Path::new(plist_path).exists() {
+        println!("cargo:warning=Info.plist not found at {}, skipping update", plist_path);
+        return;
+    }
+    
+    // Read the current Info.plist
+    let content = match fs::read_to_string(plist_path) {
+        Ok(content) => content,
+        Err(e) => {
+            println!("cargo:warning=Failed to read Info.plist: {}", e);
+            return;
+        }
+    };
+    
+    // Update CFBundleVersion using regex replacement
+    let updated_content = if let Some(start) = content.find("<key>CFBundleVersion</key>") {
+        if let Some(value_start) = content[start..].find("<string>") {
+            if let Some(value_end) = content[start + value_start + 8..].find("</string>") {
+                let before = &content[..start + value_start + 8];
+                let after = &content[start + value_start + 8 + value_end..];
+                format!("{}{}{}", before, build_timestamp, after)
+            } else {
+                content
+            }
+        } else {
+            content
+        }
+    } else {
+        content
+    };
+    
+    // Write back the updated content
+    if let Err(e) = fs::write(plist_path, updated_content) {
+        println!("cargo:warning=Failed to write updated Info.plist: {}", e);
+    } else {
+        println!("cargo:warning=Updated CFBundleVersion in Info.plist to {}", build_timestamp);
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -59,10 +59,14 @@ fn capture_build_info() {
     let build_string = format!("{}.{}", env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string()), build_timestamp);
     println!("cargo:rustc-env=BUILD_STRING={}", build_string);
     
-    // Always update Info.plist with the build timestamp if it exists
-    // This ensures consistent versioning across all builds
-    update_info_plist(&build_timestamp);
-    println!("cargo:rustc-env=BUNDLE_VERSION={}", build_timestamp);
+    // For macOS, automatically update Info.plist with the build timestamp
+    if target_os == "macos" {
+        update_info_plist(&build_timestamp);
+        println!("cargo:rustc-env=BUNDLE_VERSION={}", build_timestamp);
+    } else {
+        // For non-macOS, still set the bundle version but don't update plist
+        println!("cargo:rustc-env=BUNDLE_VERSION={}", build_timestamp);
+    }
     
     // Tell cargo to rerun this if git changes or Info.plist changes
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -13,6 +13,7 @@ impl BuildInfo {
     }
     
     /// Get the full git commit hash
+    #[allow(dead_code)]
     pub fn git_hash() -> &'static str {
         env!("GIT_HASH")
     }
@@ -49,7 +50,7 @@ impl BuildInfo {
     }
     
     /// Get detailed build information for about dialogs
-    #[allow(unused_mut)]
+    #[allow(dead_code, unused_mut)]
     pub fn detailed_info() -> String {
         let mut info = format!(
             "Version: {}\nBuild: {}\nCommit: {}\nPlatform: {}\nProfile: {}",

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,82 @@
+/// Build information captured at compile time
+pub struct BuildInfo;
+
+impl BuildInfo {
+    /// Get the package version from Cargo.toml
+    pub fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+    
+    /// Get the build timestamp in YYYYMMDD.HHMMSS format
+    pub fn build_timestamp() -> &'static str {
+        env!("BUILD_TIMESTAMP")
+    }
+    
+    /// Get the full git commit hash
+    pub fn git_hash() -> &'static str {
+        env!("GIT_HASH")
+    }
+    
+    /// Get the short git commit hash (first 7 characters)
+    pub fn git_hash_short() -> &'static str {
+        env!("GIT_HASH_SHORT")
+    }
+    
+    /// Get the target platform (arch-os)
+    pub fn target_platform() -> &'static str {
+        env!("TARGET_PLATFORM")
+    }
+    
+    /// Get the build profile (debug/release)
+    pub fn build_profile() -> &'static str {
+        env!("BUILD_PROFILE")
+    }
+    
+    /// Get the combined build string (version.timestamp)
+    pub fn build_string() -> &'static str {
+        env!("BUILD_STRING")
+    }
+    
+    /// Get the bundle version (macOS specific)
+    #[cfg(target_os = "macos")]
+    pub fn bundle_version() -> &'static str {
+        env!("BUNDLE_VERSION")
+    }
+    
+    /// Get a formatted version string for display
+    pub fn display_version() -> String {
+        format!("{} ({})", Self::version(), Self::build_timestamp())
+    }
+    
+    /// Get detailed build information for about dialogs
+    #[allow(unused_mut)]
+    pub fn detailed_info() -> String {
+        let mut info = format!(
+            "Version: {}\nBuild: {}\nCommit: {}\nPlatform: {}\nProfile: {}",
+            Self::version(),
+            Self::build_timestamp(),
+            Self::git_hash_short(),
+            Self::target_platform(),
+            Self::build_profile()
+        );
+        
+        #[cfg(target_os = "macos")]
+        {
+            info.push_str(&format!("\nBundle: {}", Self::bundle_version()));
+        }
+        
+        info
+    }
+    
+    /// Get bundle version information for display (returns empty string on non-macOS)
+    pub fn bundle_version_display() -> &'static str {
+        #[cfg(target_os = "macos")]
+        {
+            Self::bundle_version()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            ""
+        }
+    }
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod loading_handler;
 mod config;
 mod app;
 mod utils;
+mod build_info;
 
 #[allow(unused_imports)]
 use log::{Level, trace, debug, info, warn, error};


### PR DESCRIPTION
- Auto-generate build timestamps on every `cargo build`
- Automatically update CFBundleVersion in Info.plist (macOS only)  
- Display build info in About modal (version, timestamp, git hash, platform)