### PR TITLE
Implement log export functionality for both debug logs and stdout output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,6 +5445,7 @@ dependencies = [
  "iced_widget",
  "iced_winit",
  "image 0.25.6",
+ "libc",
  "log",
  "memmap2",
  "num-traits 0.2.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ memmap2 = "0.9.5"
 rayon = "1.8"
 texpresso = { version = "2.0.1", features = ["rayon"] }
 sysinfo = "0.33.1"
+libc = "0.2"
 
 # Use custom iced
 iced_custom = { package = "iced", git = "https://github.com/ggand0/iced.git", branch = "custom-0.13", features = [

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -595,6 +595,8 @@ pub fn get_log_directory(app_name: &str) -> PathBuf {
 /// * `Ok(PathBuf)` - The path to the created debug log file
 /// * `Err(std::io::Error)` - An error if the export fails
 pub fn export_debug_logs(app_name: &str, log_buffer: Arc<Mutex<VecDeque<String>>>) -> Result<PathBuf, std::io::Error> {
+    // NOTE: Use println! instead of debug! to avoid circular logging
+    // (debug! calls would be added to the same buffer we're trying to export)
     println!("DEBUG: export_debug_logs called");
     
     let log_dir_path = get_log_directory(app_name);
@@ -694,7 +696,7 @@ pub fn export_debug_logs(app_name: &str, log_buffer: Arc<Mutex<VecDeque<String>>
 /// * `app_name` - The application name used for the log directory
 /// * `log_buffer` - The shared log buffer containing the recent log messages
 pub fn export_and_open_debug_logs(app_name: &str, log_buffer: Arc<Mutex<VecDeque<String>>>) {
-    // Debug: Check if this is the same buffer that should be receiving logs
+    // NOTE: Use println! to avoid circular logging during export operations
     println!("DEBUG: About to export debug logs...");
     if let Ok(buffer) = log_buffer.lock() {
         println!("DEBUG: Buffer size at export time: {}", buffer.len());
@@ -1022,7 +1024,7 @@ pub fn export_stdout_logs(app_name: &str, stdout_buffer: Arc<Mutex<VecDeque<Stri
 /// * `log_buffer` - The shared log buffer containing recent log messages
 /// * `stdout_buffer` - The shared stdout buffer containing captured output
 pub fn export_and_open_all_logs(app_name: &str, log_buffer: Arc<Mutex<VecDeque<String>>>, stdout_buffer: Arc<Mutex<VecDeque<String>>>) {
-    // Debug: Check both buffers
+    // NOTE: Use println! to avoid circular logging during export operations
     println!("DEBUG: About to export all logs...");
     if let Ok(log_buf) = log_buffer.lock() {
         println!("DEBUG: Log buffer size: {}", log_buf.len());

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -31,9 +31,6 @@ use crate::cache::img_cache::CacheStrategy;
 use iced_wgpu::engine::CompressionStrategy;
 use std::thread;
 
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-
 static IMAGE_LOAD_STATS: Lazy<Mutex<TimingStats>> = Lazy::new(|| {
     Mutex::new(TimingStats::new("Image Load"))
 });
@@ -662,10 +659,7 @@ pub fn export_debug_logs(app_name: &str, log_buffer: Arc<Mutex<VecDeque<String>>
         writeln!(file, "{} [DEBUG EXPORT] =====================================", timestamp)?;
         writeln!(file)?; // Empty line for readability
         
-        for (i, log_entry) in log_entries.iter().enumerate() {
-            if i % 10 == 0 {
-                println!("DEBUG: Writing entry {}/{}", i, buffer_size);
-            }
+        for (_i, log_entry) in log_entries.iter().enumerate() {
             writeln!(file, "{} {}", timestamp, log_entry)?;
         }
         println!("DEBUG: All entries written");
@@ -834,7 +828,7 @@ pub fn open_in_file_explorer(path: &str) {
 /// * `Arc<Mutex<VecDeque<String>>>` - The shared stdout buffer
 #[cfg(unix)]
 pub fn setup_stdout_capture() -> Arc<Mutex<VecDeque<String>>> {
-    use std::os::unix::io::{AsRawFd, FromRawFd};
+    use std::os::unix::io::FromRawFd;
     use std::fs::File;
     use std::io::{BufReader, BufRead};
     
@@ -951,13 +945,6 @@ pub fn setup_stdout_capture() -> Arc<Mutex<VecDeque<String>>> {
     println!("Stdout capture initialized (manual mode) - use capture_stdout() for important messages");
     
     Arc::clone(&STDOUT_BUFFER)
-}
-
-/// Disables stdout capture and restores normal stdout
-/// 
-/// This function should be called when shutting down to restore normal stdout behavior.
-pub fn disable_stdout_capture() {
-    STDOUT_CAPTURE_ENABLED.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
 /// Exports stdout logs to a separate file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,6 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
     set_shared_stdout_buffer(Arc::clone(&shared_stdout_buffer));
     
     println!("ViewSkater starting...");
-    file_io::capture_stdout("ViewSkater starting...");
     
     // Set up panic hook to log to a file
     let app_name = "viewskater";
@@ -234,7 +233,6 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
         macos_file_handler::set_file_channel(file_sender);
         macos_file_handler::register_file_handler();
         println!("macOS file handler registered");
-        file_io::capture_stdout("macOS file handler registered");
     }
 
     // Handle command line arguments for Linux (and Windows)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -364,6 +364,8 @@ pub fn menu_help<'a>(_app: &DataViewer) -> Menu<'a, Message, WinitTheme, Rendere
         menu_items!(
             (labeled_button("About", MENU_ITEM_FONT_SIZE, Message::ShowAbout))
             (labeled_button("Show logs", MENU_ITEM_FONT_SIZE, Message::ShowLogs))
+            (labeled_button("Export debug logs", MENU_ITEM_FONT_SIZE, Message::ExportDebugLogs))
+            (labeled_button("Export all logs", MENU_ITEM_FONT_SIZE, Message::ExportAllLogs))
         )
     )
 }


### PR DESCRIPTION
Adds a new menu item to export debug logs and stdout output that works both local and appstore builds.

- Export debug logs (from Rust log macros) to debug.log
- Export stdout logs (from println! statements) to stdout.log
- Add menu options: "Export debug logs" and "Export all logs"
- Support up to 1000 log entries per buffer with circular storage