### PR TITLE
Fix crash on large images by limiting texture size

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It aims to alleviate the challenges of exploring and comparing numerous images. 
 - Dynamic image caching on CPU or GPU memory
 - Continuous image rendering via key presses and the slider UI
 - Dual pane view for side-by-side image comparison
-- Supports image formats supported by the `image` crate up to 8192×8192 px  
-  (JPG, PNG, GIF, BMP, TIFF, WebP, QOI, TGA, etc.)
+- Supports image formats supported by the image crate (JPG, PNG, GIF, BMP, TIFF, WebP, QOI, TGA, etc.)
+- Renders images up to 8192×8192 px (larger images are resized to fit)
 
 ## Installation
 Download the pre-built binaries from the [releases page](https://github.com/ggand0/viewskater/releases), or build it locally:

--- a/src/cache/gpu_img_cache.rs
+++ b/src/cache/gpu_img_cache.rs
@@ -29,7 +29,8 @@ impl ImageCacheBackend for GpuImageCache {
         compression_strategy: CompressionStrategy
     ) -> Result<CachedData, io::Error> {
         if let Some(image_path) = image_paths.get(index) {
-            let img = image::open(image_path).map_err(|e| {
+            // Use the safe load_original_image function to prevent crashes with oversized images
+            let img = crate::cache::cache_utils::load_original_image(image_path).map_err(|e| {
                 io::Error::new(io::ErrorKind::InvalidData, format!("Failed to open image: {}", e))
             })?;
 

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -171,7 +171,8 @@ async fn load_image_gpu_async(
     if let Some(path_str) = path {
         let start = Instant::now();
 
-        match image::open(path_str) {
+        // Use the safe load_original_image function from cache_utils to prevent crashes with oversized images
+        match crate::cache::cache_utils::load_original_image(std::path::Path::new(path_str)) {
             Ok(img) => {
                 let (width, height) = img.dimensions();
                 let rgba = img.to_rgba8();

--- a/src/navigation_slider.rs
+++ b/src/navigation_slider.rs
@@ -535,7 +535,8 @@ fn load_current_slider_image(pane: &mut pane::Pane, pos: usize) -> Result<(), io
     };
     
     // Always load from file directly for best slider performance
-    match image::open(img_path) {
+    // Use the safe load_original_image function to prevent crashes with oversized images  
+    match crate::cache::cache_utils::load_original_image(img_path) {
         Ok(img) => {
             // Resize the image to smaller dimensions for slider
             /*let resized = img.resize(


### PR DESCRIPTION
Fixes crash when rendering images with a longer edge over 8192 px by resizing them.
Closes #49.

- Automatically resizes images larger than 8192 px on the longer edge, preserving aspect ratio
- Refactors image loading in `cache_utils` into smaller, focused functions
- Adds `cache_utils::check_and_resize_if_oversized()` for safe resizing before upload