### PR TITLE
Fix panic when loading images >8192px via slider navigation

### DIFF
--- a/src/cache/cache_utils.rs
+++ b/src/cache/cache_utils.rs
@@ -17,7 +17,7 @@ use log::{debug, info, warn, error};
 const MAX_TEXTURE_SIZE: u32 = 8192;
 
 /// Checks if image exceeds MAX_TEXTURE_SIZE and resizes if needed while preserving aspect ratio
-fn check_and_resize_if_oversized(img: DynamicImage) -> DynamicImage {
+pub fn check_and_resize_if_oversized(img: DynamicImage) -> DynamicImage {
     let (width, height) = img.dimensions();
 
     if width > MAX_TEXTURE_SIZE || height > MAX_TEXTURE_SIZE {

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -265,6 +265,9 @@ async fn load_image_gpu_async(
 
         match img_result {
             Ok(img) => {
+                // Apply size check and resize if image exceeds 8192px limit
+                let img = crate::cache::cache_utils::check_and_resize_if_oversized(img);
+
                 let (width, height) = img.dimensions();
                 let rgba = img.to_rgba8();
                 let rgba_data = rgba.as_raw();


### PR DESCRIPTION
## Summary
- Fix texture size validation in async GPU image loading
- Prevent panic when navigating to images >8192px with slider

## Problem
Images exceeding 8192px caused panics during slider navigation:
```
wgpu error: Dimension X value 11847 exceeds the limit of 8192
```

## Solution
Made `check_and_resize_if_oversized()` public and added the size check to `load_image_gpu_async()` before texture creation. This ensures consistent handling across all loading paths.

Closes #66