### PR TITLE
Add JPEG 2000 (.jp2) format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,6 +2903,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg2k"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2982db6b9f254c9df44d89bcfdc758924d538f576d9649f5b10008150f2a60"
+dependencies = [
+ "anyhow",
+ "image 0.25.8",
+ "log",
+ "openjp2",
+ "openjpeg-sys",
+ "thiserror",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,6 +3893,30 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openjp2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8940f4ff209130c7b374730e83cc7e31062706520e3960001e7eedc982bc554"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "log",
+ "smallvec",
+ "sprintf",
+]
+
+[[package]]
+name = "openjpeg-sys"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92682cb92e7b01e2c020cf8ec12f3374558924bb24621df1112d8a7c93d419ef"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
@@ -5225,6 +5269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprintf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0cdea5a20a06e7c57f627094e7b1618e5665592cd88f2d45fa4014e348db58"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,6 +5930,7 @@ dependencies = [
  "iced_widget",
  "iced_winit",
  "image 0.25.8",
+ "jpeg2k",
  "libc",
  "log",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 regex = "1.10"
+jpeg2k = { version = "0.10", optional = true, features = ["image"] }
 
 # Use custom iced
 iced_custom = { package = "iced", git = "https://github.com/ggand0/iced.git", branch = "custom-0.13", features = [
@@ -69,6 +70,8 @@ iced_aw = { package = "iced_aw", git = "https://github.com/ggand0/iced_aw.git", 
 selection = []
 # COCO dataset visualization (disabled by default)
 coco = []
+# JPEG 2000 support (disabled by default)
+jp2 = ["dep:jpeg2k"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"

--- a/src/cache/cache_utils.rs
+++ b/src/cache/cache_utils.rs
@@ -1,8 +1,7 @@
-use std::io::Cursor;
 use std::io;
 #[allow(unused_imports)]
 use image::GenericImageView;
-use image::{DynamicImage, ImageReader};
+use image::DynamicImage;
 use std::sync::Arc;
 use wgpu::{Device, Queue};
 use iced_wgpu::wgpu;
@@ -41,8 +40,8 @@ pub fn load_original_image(path_source: &crate::cache::img_cache::PathSource, ar
     let img = {
         // Use PathSource-aware unified function
         let bytes = crate::file_io::read_image_bytes(path_source, archive_cache)?;
-        ImageReader::new(Cursor::new(bytes)).with_guessed_format()?.decode()
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to read image from PathSource: {e} {}", path_source.file_name())))?
+        crate::file_io::decode_image_from_bytes(&bytes)
+            .map_err(|e| io::Error::new(e, format!("Failed to read image from PathSource: {}", path_source.file_name())))?
     };
     Ok(check_and_resize_if_oversized(img))
 }
@@ -52,8 +51,8 @@ pub fn load_and_resize_image(path_source: &crate::cache::img_cache::PathSource, 
     let img = {
         // Use PathSource-aware unified function
         let bytes = crate::file_io::read_image_bytes(path_source, archive_cache)?;
-        ImageReader::new(Cursor::new(bytes)).with_guessed_format()?.decode()
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to read image from PathSource: {e} {}", path_source.file_name())))?
+        crate::file_io::decode_image_from_bytes(&bytes)
+            .map_err(|e| io::Error::new(e, format!("Failed to read image from PathSource: {}", path_source.file_name())))?
     };
     let (original_width, original_height) = img.dimensions();
     info!("Resizing image: {}x{} -> {}x{}", original_width, original_height, target_width, target_height);


### PR DESCRIPTION
- Add JPEG 2000 (.jp2, .j2k, .j2c) format support behind an optional `jp2` feature flag
- Uses the `jpeg2k` crate with OpenJPEG backend for decoding
- Detects JP2 files via magic bytes for reliable format identification

This feature was requested via email.

Usage:
```bash
cargo run --features jp2
```